### PR TITLE
Feat/change password

### DIFF
--- a/src/main/java/com/helpduck/helpduckusers/controller/UserController.java
+++ b/src/main/java/com/helpduck/helpduckusers/controller/UserController.java
@@ -93,10 +93,11 @@ public class UserController {
 		return new ResponseEntity<User>(status);
 	}
 
-	@PutMapping("/update-password/{userId}")
-	public ResponseEntity<User> updatePassword(@PathVariable String userId, @RequestBody ObjectNode objectNode) {
+	@PutMapping("/update-password")
+	public ResponseEntity<User> updatePassword(@RequestBody ObjectNode objectNode) {
 
 		HttpStatus status = HttpStatus.CONFLICT;
+		String userId = objectNode.get("userId").asText();
 		String newPassword = objectNode.get("newPassword").asText();
 		String oldPassword = objectNode.get("oldPassword").asText();
 
@@ -114,7 +115,6 @@ public class UserController {
 			}
 
 		} else {
-
 			status = HttpStatus.BAD_REQUEST;
 		}
 


### PR DESCRIPTION
  #15  

- [x] change the user's password to another one, if he enters the old password correctly.
- [x] keep the user's new password encrypted
- [x] apply the correct http method in any cases (400, 401, 200, 409).

endpoint: /users/update-password

Authenticating with password "1234"

![image](https://user-images.githubusercontent.com/55204419/170574820-7bb20d92-4c67-48a1-a396-f5c571844d9d.png)


Changing the password from "1234" to "1"

![image](https://user-images.githubusercontent.com/55204419/170574884-9947c6a7-ea7b-41db-b926-86ed2d06f59a.png)


When trying to authenticate with the old password:

![image](https://user-images.githubusercontent.com/55204419/170574948-54168dd8-23b2-457d-9a06-502f9bd8b035.png)


Trying to authenticate with the new password:

![image](https://user-images.githubusercontent.com/55204419/170574978-25f4ba69-08b1-4a9a-b266-e968db9aa8fd.png)


Putting wrong current password, when trying to change password:

![image](https://user-images.githubusercontent.com/55204419/170575740-d3d0d153-5eb4-4f4d-876c-71ae08a8209c.png)

