### PR TITLE
Feat/filter user per role

### DIFF
--- a/src/main/java/com/helpduck/helpduckusers/repository/UserRepository.java
+++ b/src/main/java/com/helpduck/helpduckusers/repository/UserRepository.java
@@ -3,9 +3,22 @@ package com.helpduck.helpduckusers.repository;
 import java.util.Optional;
 
 import com.helpduck.helpduckusers.entity.User;
+import com.helpduck.helpduckusers.enums.RoleEnum;
 
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 public interface UserRepository extends MongoRepository<User, String> {
   Optional<User> findByEmail(String email);
+
+  // { }
+  @Query("{ $or: [ {'firstName': { $regex:?0, '$options' : 'i' }}, {'lastName': { $regex:?0, '$options' : 'i' }} ]}")
+  Page<User> searchUsername(Pageable page, String username);
+
+  @Query("{ $or: [ {'firstName': { $regex:?0, '$options' : 'i' }}, {'lastName': { $regex:?0, '$options' : 'i' }} ],  $and: [{'role': ?1 }] }")
+  Page<User> searchUsernameAndFilterPerRole(Pageable page, String username, RoleEnum role);
+
+  Page<User> findByRole(Pageable page, RoleEnum role);
 }


### PR DESCRIPTION
### Salve salve camaradas, excelente semana pra você que está lendo 🙌 

#17 - Implementado filtro de usuário por cargo e também pelo nome de usuário;

### Mas como funciona essa belezinha ? vem comigo..

#### Para realizar esses filtros basta utilizar o endpoint abaixo:

```URI:  <URL-REGISTER>/users/search```

#### Agora que vem o chan

### Para realizar filtro por cargo (role), basta passar o parâmetro abaixo na requisição:

- Filtro por administradores
```URI:  <URL-REGISTER>/users/search?role=admin```

- Filtro por suporte
```URI:  <URL-REGISTER>/users/search?role=support```

- Filtro por clientes
```URI:  <URL-REGISTER>/users/search?role=client```

---

#### Mas e se quisermos filtrar por nome de usuário ?

### Basta adicionar o parâmetro username:

- Essa busca é feita tanto por nome como sobrenome 😄 

```URI:  <URL-REGISTER>/users/search?username=nomedousuário```

#### MAAAAS, e se eu quiser filtrar os dois ? Da também HEHE

- Basta passar os dois parâmetros separados por um E comercial (&):

```URI:  <URL-REGISTER>/users/search?role=admin&username=teste```

- A ordem tanto faz (role primeiro, como por último 🤷‍♂️), mas a sintaxe é separar o parâmetros pelo & 